### PR TITLE
Comment out optional automation libraries in requirements

### DIFF
--- a/{{ cookiecutter.bot_name.replace(' ', '_') }}/requirements.txt
+++ b/{{ cookiecutter.bot_name.replace(' ', '_') }}/requirements.txt
@@ -9,11 +9,11 @@ configparser>=5.0.0       # For config management
 
 # Common automation libraries (uncomment as needed)
 requests>=2.25.0          # For web requests and APIs
-beautifulsoup4>=4.9.0     # For web scraping  
-selenium>=4.0.0           # For browser automation
-openpyxl>=3.0.0          # For Excel files
-pandas>=1.3.0            # For data processing
-pillow>=8.0.0            # For image processing
+#beautifulsoup4>=4.9.0     # For web scraping  
+#selenium>=4.0.0           # For browser automation
+#openpyxl>=3.0.0          # For Excel files
+#pandas>=1.3.0            # For data processing
+#pillow>=8.0.0            # For image processing
 
 # Email automation
 # smtplib (built-in)


### PR DESCRIPTION
Commented out beautifulsoup4, selenium, openpyxl, pandas, and pillow in requirements.txt to make them optional. This helps reduce unnecessary dependencies unless explicitly needed for the project.